### PR TITLE
Changed naming of Get Drive

### DIFF
--- a/Microsoft Graph v1.0.postman_collection.json
+++ b/Microsoft Graph v1.0.postman_collection.json
@@ -1046,7 +1046,7 @@
 					"name": "Files",
 					"item": [
 						{
-							"name": "Get Drive",
+							"name": "Get Drive Files",
 							"event": [
 								{
 									"listen": "test",


### PR DESCRIPTION
Get Drive should return the onedrive not the the children so changed to reflect what is actually returned