### PR TITLE
Fixed broken Markdown syntax on Postman link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The most up-to-date experience to explore the APIs will always be [Microsoft Gra
 
 To setup the Postman collections follow these steps:
 
-**1.** Download and register for [Postman](https://www.getpostman.com/. Note: Make sure to install the latest version).
+**1.** Download and register for [Postman](https://www.getpostman.com/). Note: Make sure to install the latest version).
 
 **2.** Click **File | Import ...**.
 


### PR DESCRIPTION
The link to Postman in step 1 of the Setup section contained some broken Markdown syntax. This commit fixes that syntax so that the link displays correctly when the Markdown is rendered.